### PR TITLE
Use either username or email

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -52,8 +52,9 @@ module.exports = {
   login: function(req, res, next) {
     if (req.body.username || req.body.email) {
       if (req.body.password) {
+        const username = req.body.username || req.body.email;
         const user = data.users.find(
-          usersearch => usersearch.email === req.body.email
+          usersearch => usersearch.email === username
         );
         if (user) {
           const token = data.tokens.find(token => token.id === user.id);
@@ -82,8 +83,9 @@ module.exports = {
   register: function(req, res, next) {
     if (req.body.username || req.body.email) {
       if (req.body.password) {
+	const username = req.body.username || req.body.email;
         const user = data.users.find(
-          usersearch => usersearch.email === req.body.email
+          usersearch => usersearch.email === username
         );
         if (user) {
           const token = data.tokens.find(token => token.id === user.id);


### PR DESCRIPTION
Prior to https://github.com/benhowdle89/reqres/pull/37/files, either `username` or `email` could be used to make a successful login via `/login`. When per user tokens were introduced, the user search only looked at `email` despite `username` being allowed through the conditional. This makes for a confusing error.

This change allows `username` to be used as expected again.